### PR TITLE
avoid lossy conversion from float to int in radius calculation

### DIFF
--- a/src/android/OpenTokAndroidPlugin.java
+++ b/src/android/OpenTokAndroidPlugin.java
@@ -86,10 +86,10 @@ public class OpenTokAndroidPlugin extends CordovaPlugin
     public CallbackContext permissionsCallback;
 
     public class CameraView extends ViewGroup {
-        int x = 0;
-        int y = 0;
-        int width = 0;
-        int height = 0;
+        float x = 0;
+        float y = 0;
+        float width = 0;
+        float height = 0;
         float[] radii = new float[8];
         TextureView view;
 


### PR DESCRIPTION
Hi Jochum,
I ran into these errors when pulling the latest code from your branch. I think this PR should fix it.

<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure you followed the Contribution Guidelines. Which can be found here:
https://github.com/opentok/cordova-plugin-opentok/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [x] Code must follow existing styling conventions
- [x] Added a descriptive commit message

### Solves issue(s)
<!--- Mention the GitHub issues here -->

```
/home/circleci/repo/platforms/android/src/com/tokbox/cordova/OpenTokAndroidPlugin.java:108: error: incompatible types: possible lossy conversion from float to int
[16:07:21]: ▸ this.x = xPos;
[16:07:21]: ▸ ^
[16:07:21]: ▸ /home/circleci/repo/platforms/android/src/com/tokbox/cordova/OpenTokAndroidPlugin.java:109: error: incompatible types: possible lossy conversion from float to int
[16:07:21]: ▸ this.y = yPos;
[16:07:21]: ▸ ^
[16:07:21]: ▸ /home/circleci/repo/platforms/android/src/com/tokbox/cordova/OpenTokAndroidPlugin.java:110: error: incompatible types: possible lossy conversion from float to int
[16:07:21]: ▸ this.width = width;
[16:07:21]: ▸ ^
[16:07:21]: ▸ /home/circleci/repo/platforms/android/src/com/tokbox/cordova/OpenTokAndroidPlugin.java:111: error: incompatible types: possible lossy conversion from float to int
[16:07:21]: ▸ this.height = height;
```